### PR TITLE
lisp: add Load() to DRY up the loading function and make it available for external packages

### DIFF
--- a/datalog/datalog.go
+++ b/datalog/datalog.go
@@ -11,14 +11,8 @@ var datalog string
 
 func Load(l lisp.Lisp) {
 	// TODO: should fail if kanren hasnt been loaded
-	sexprs, err := lisp.Multiparse(datalog)
+	err := l.Load(datalog)
 	if err != nil {
 		panic(err)
-	}
-	for _, def := range sexprs {
-		_, err := l.EvalExpr(def)
-		if err != nil {
-			panic(err)
-		}
 	}
 }

--- a/kanren/kanren.go
+++ b/kanren/kanren.go
@@ -10,14 +10,8 @@ import (
 var kanren string
 
 func Load(l lisp.Lisp) {
-	sexprs, err := lisp.Multiparse(kanren)
+	err := l.Load(kanren)
 	if err != nil {
 		panic(err)
-	}
-	for _, def := range sexprs {
-		_, err := l.EvalExpr(def)
-		if err != nil {
-			panic(err)
-		}
 	}
 }

--- a/lisp/loader.go
+++ b/lisp/loader.go
@@ -1,0 +1,17 @@
+package lisp
+
+// Load a string of lisp code/data into the environment.
+func (l Lisp) Load(data string) error {
+	sexprs, err := Multiparse(data)
+	if err != nil {
+		return err
+	}
+	for _, def := range sexprs {
+		_, err := l.EvalExpr(def)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/lisp/loader_test.go
+++ b/lisp/loader_test.go
@@ -1,0 +1,27 @@
+package lisp
+
+import "testing"
+
+func TestLoader(t *testing.T) {
+	l := New()
+	l.Load("(define r 10)")
+
+	for i, tt := range []struct {
+		input string
+		want  string
+	}{
+		{
+			input: "(* pi (* r r))",
+			want:  "314.1592653589793",
+		},
+	} {
+		e, err := l.Eval(tt.input)
+		if err != nil {
+			t.Errorf("%d) eval error %v", i, err)
+		}
+		got := e.String()
+		if got != tt.want {
+			t.Errorf("%d) got %s want %s", i, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a Load() function to the main `lisp` package to both DRY up the loading function for internal packages like `datalog` and also make it easier for external packages that just want to use the default implementation.