### PR TITLE
fix: recover panics in Eval/EvalExpr

### DIFF
--- a/lisp/lisp.go
+++ b/lisp/lisp.go
@@ -16,7 +16,12 @@ func New() Lisp {
 	return Lisp{p, env}
 }
 
-func (l Lisp) Eval(input string) (SExpression, error) {
+func (l Lisp) Eval(input string) (result SExpression, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%v", r)
+		}
+	}()
 	sexp, err := parse(input)
 	if err != nil {
 		return nil, err
@@ -28,7 +33,12 @@ func (l Lisp) Eval(input string) (SExpression, error) {
 	return l.process.evalEnv(l.Env, sexp)
 }
 
-func (l Lisp) EvalExpr(e SExpression) (SExpression, error) {
+func (l Lisp) EvalExpr(e SExpression) (result SExpression, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%v", r)
+		}
+	}()
 	if l.process.evalWithContinuation {
 		id := func(x SExpression) SExpression { return x }
 		return l.process.evalEnvK(l.Env, e, id), nil

--- a/lisp/lisp_test.go
+++ b/lisp/lisp_test.go
@@ -188,6 +188,38 @@ func TestTailRecursion(t *testing.T) {
 	}
 }
 
+func TestPanicRecovery(t *testing.T) {
+	for i, tt := range []struct {
+		setup string
+		input string
+	}{
+		{
+			// car on a non-pair atom panics inside the builtin
+			input: "(car 42)",
+		},
+		{
+			// cdr on a non-pair atom panics inside the builtin
+			input: "(cdr 42)",
+		},
+		{
+			// symbol bound to an atom, then car applied — mirrors the eliza crash
+			setup: "(define yes #t)",
+			input: "(car yes)",
+		},
+	} {
+		l := New()
+		if tt.setup != "" {
+			if _, err := l.Eval(tt.setup); err != nil {
+				t.Fatalf("%d) setup error: %v", i, err)
+			}
+		}
+		_, err := l.Eval(tt.input)
+		if err == nil {
+			t.Errorf("%d) expected error from %q, got nil", i, tt.input)
+		}
+	}
+}
+
 func TestCopyEnv(t *testing.T) {
 	// TODO: copyEnv doesnt copy envs enclosed in lambda defs! race conditions!
 	main := newProcess()


### PR DESCRIPTION
This PR is to fix the problem where invalid input would crash the interpreter. Now it can return an error such as `not a pair` instead.